### PR TITLE
Change shebang to use env for Python

### DIFF
--- a/perplexity.py
+++ b/perplexity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import logging
 import argparse
 import os


### PR DESCRIPTION
As a general good practice, it's worth using an env shebang. What's more, it was already brought up in #2.